### PR TITLE
Support negative numbers

### DIFF
--- a/syntaxes/idf.tmLanguage.json
+++ b/syntaxes/idf.tmLanguage.json
@@ -73,7 +73,7 @@
             "name":        "constant.language.boolean.idf"
         },
         "number": {
-            "match":       "^\\s*\\d+(?:\\.\\d+)?\\s*(?=,|;)",
+            "match":       "^\\s*-?\\d+(?:\\.\\d+)?\\s*(?=,|;)",
             "name":        "constant.numeric.idf"
         },
         "string": {


### PR DESCRIPTION
This PR fixes the case where negative numbers are incorrectly interpreted as strings.

_Before_:
![Original](https://user-images.githubusercontent.com/411466/152873203-bf66ef45-9af8-4dbf-b240-b8f08b79281c.png)

_After_:
![Fixed](https://user-images.githubusercontent.com/411466/152873226-234b2e04-463e-47b2-ada0-1462456c93d9.png)

